### PR TITLE
added gen_smtp to the .app

### DIFF
--- a/src/nkmail.app.src
+++ b/src/nkmail.app.src
@@ -4,6 +4,6 @@
     {modules, []},
     {registered, []},
     {mod, {nkmail_app, []}},
-    {applications, [nkservice, nkapi]},
+    {applications, [gen_smtp, nkservice, nkapi]},
     {env, []}
 ]}.


### PR DESCRIPTION
This dependency will be automatically added in the netcomp release and parsing of email address will work properly. 